### PR TITLE
update toolbox path parameters

### DIFF
--- a/docs/LFS173x/AriesToolboxLab.md
+++ b/docs/LFS173x/AriesToolboxLab.md
@@ -70,9 +70,8 @@ Get a local clone of the Aries ACA-Py Plugins Toolbox repo and use docker-compos
 
 ```
 git clone https://github.com/hyperledger/aries-acapy-plugin-toolbox
-cd aries-acapy-plugin-toolbox
-docker-compose -f docker-compose_alice_bob.yml up --build
-
+cd aries-acapy-plugin-toolbox/demo
+docker-compose -f docker-compose.alice-bob.yml up --build
 ```
 
 

--- a/docs/LFS173xV2/AriesToolboxLab.md
+++ b/docs/LFS173xV2/AriesToolboxLab.md
@@ -70,8 +70,8 @@ Get a local clone of the Aries ACA-Py Plugins Toolbox repo and use docker-compos
 
 ```
 git clone https://github.com/hyperledger/aries-acapy-plugin-toolbox
-cd aries-acapy-plugin-toolbox
-docker-compose -f docker-compose_alice_bob.yml up --build
+cd aries-acapy-plugin-toolbox/demo
+docker-compose -f docker-compose.alice-bob.yml up --build
 
 ```
 


### PR DESCRIPTION
Fix path parameters to match latest structure of [aries-acapy-plugin-toolbox](https://github.com/hyperledger/aries-acapy-plugin-toolbox).

Also, note that edX Course / Chapter 6. Aries Development Tools /The Aries Toolbox links to [LFS173x](https://github.com/cloudcompass/ToIPLabs/tree/master/docs/LFS173x), not [LFS173xV2](https://github.com/cloudcompass/ToIPLabs/tree/master/docs/LFS173xV2).

Signed-off-by: Emo Abadjiev <emo@tumba.solutions>