### PR TITLE
Correct minor typo in text

### DIFF
--- a/docs/LFS172x/running-aries-browser-lab.md
+++ b/docs/LFS172x/running-aries-browser-lab.md
@@ -1,6 +1,6 @@
 # Hyperledger Indy, Aries and Ursa Demonstrations
 
-Welcome to the demonstration section of the Linux Foundation's edX course LF172x, Introduction to Hyperledger Sovereign Identity Blockchain Solutions: Indy, Aries and Ursa. In this section we have two demonstrations of Indy, Aries and Ursa technology.
+Welcome to the demonstration section of the Linux Foundation's edX course LFS172x, Introduction to Hyperledger Sovereign Identity Blockchain Solutions: Indy, Aries and Ursa. In this section we have two demonstrations of Indy, Aries and Ursa technology.
 
 ## Mobile Agent Demonstration
 


### PR DESCRIPTION
The Course LFS172x was erroneously referred to as LF172x, this commit fixes that typo.