### PR TITLE
Adjust lab links

### DIFF
--- a/docs/LFS173xV2/ACA-PyStartup.md
+++ b/docs/LFS173xV2/ACA-PyStartup.md
@@ -12,7 +12,7 @@ This lab can be run locally with Docker or on Play with Docker in your browser. 
 
 ## Instructions
 
-For this lab, we are going to use [these instructions in the ACA-Py repository](https://github.com/hyperledger/aries-cloudagent-python/blob/main/DevReadMe.md#configuring-aca-py-command-line-parameters) to review the current set of command line parameters for ACA-Py. To prepare to run the lab, clone the ACA-Py github repo (locally or on Play with Docker):
+For this lab, we are going to use [these instructions in the ACA-Py repository](https://github.com/hyperledger/aries-cloudagent-python/blob/main/docs/features/DevReadMe.md#configuring-aca-py-command-line-parameters) to review the current set of command line parameters for ACA-Py. To prepare to run the lab, clone the ACA-Py github repo (locally or on Play with Docker):
 
 ```bash
 git clone https://github.com/hyperledger/aries-cloudagent-python

--- a/docs/LFS173xV2/AliceGetsCredential.md
+++ b/docs/LFS173xV2/AliceGetsCredential.md
@@ -22,7 +22,7 @@ This lab from the ACA-Py repository includes details about running the example l
 
 ## Instructions
 
-We’re again going to use the tutorial in the ACA-Py repository to spin up agents for Alice and Faber, have them connect, exchange messages and issue and prove a verifiable credential. Follow the [instructions here](https://github.com/hyperledger/aries-cloudagent-python/tree/main/demo#the-alicefaber-python-demo), this time completing the full tutorial.
+We’re again going to use the tutorial on the ACA-Py Documentation site to spin up agents for Alice and Faber, have them connect, exchange messages and issue and prove a verifiable credential. Follow the [instructions here](https://aca-py.org/latest/demo/), this time completing the full tutorial.
 
 When we ran this code in an earlier lab, we linked to the specific lines of controller code that handled the early part of the demo. Here are the key elements of the credential exchange handling within the controllers. Recall that the actual calls to the `indy-sdk` are embedded in ACA-Py, and the controller just has to use the REST API exposed by the API agent to trigger and handle the agent-related actions.
 

--- a/docs/LFS173xV2/FaberRevokesAliceCredential.md
+++ b/docs/LFS173xV2/FaberRevokesAliceCredential.md
@@ -14,7 +14,7 @@ This lab can be run locally with Docker or on Play with Docker in your browser. 
 
 ## Instructions
 
-We’re again going to use the tutorial in the ACA-Py repository to spin up agents for Alice and Faber, have them connect, exchange messages and issue and prove a verifiable credential. Follow the [instructions here](https://github.com/hyperledger/aries-cloudagent-python/blob/main/demo/AliceGetsAPhone.md). The differences from the previous runs of
+We’re again going to use the tutorial on the ACA-Py Documentation site to spin up agents for Alice and Faber, have them connect, exchange messages and issue and prove a verifiable credential. Follow the [instructions here](https://aca-py.org/latest/demo/AliceGetsAPhone/). The differences from the previous runs of
 the Alice-Faber demo we have run are:
 
 - We have to run a Revocation Tails Server to run the demo.
@@ -25,7 +25,7 @@ the Alice-Faber demo we have run are:
 
 Other than that, you should find the instructions pretty similar. Give it a try!
 
-By the way, this lab can be done without the mobile phone part. You still need to have the extra tails server, but you can run the Alice command line agent exactly as you did in the initial Alice-Faber scenario. When Faber has revocation activated, the extra commands are available, and you can use the just as with the mobile demo. The details of that are outlined [here](https://github.com/hyperledger/aries-cloudagent-python/blob/main/demo/README.md#revocation) in the demo folder's README.md file. Don't forget to start the Tails Server before you begin!
+By the way, this lab can be done without the mobile phone part. You still need to have the extra tails server, but you can run the Alice command line agent exactly as you did in the initial Alice-Faber scenario. When Faber has revocation activated, the extra commands are available, and you can use the just as with the mobile demo. The details of that are outlined [here](https://aca-py.org/latest/demo/#revocation) on the ACA-Py documentation site. Don't forget to start the Tails Server before you begin!
 
 ## Takeaways
 

--- a/docs/LFS173xV2/HelpAliceGetAJob.md
+++ b/docs/LFS173xV2/HelpAliceGetAJob.md
@@ -20,7 +20,7 @@ cd aries-cloudagent-python/demo
 
 ```
 
-The instructions for getting started with the coding [are here](https://github.com/hyperledger/aries-cloudagent-python/blob/main/demo/AcmeDemoWorkshop.md).
+The instructions for getting started with the coding [are here](https://aca-py.org/latest/demo/AcmeDemoWorkshop/).
 
 ## Takeaways
 

--- a/docs/LFS173xV2/OpenAPIController.md
+++ b/docs/LFS173xV2/OpenAPIController.md
@@ -12,7 +12,7 @@ This lab can be run locally with Docker or on Play with Docker in your browser. 
 
 ## Instructions
 
-The instructions for this lab can be found [here](https://github.com/hyperledger/aries-cloudagent-python/blob/main/demo/AriesOpenAPIDemo.md) in the ACA-Py repository. As you carry out the instructions, keep track of who you are on each step (Alice’s or Faber’s controller) and consider how you would code an application to automate the manual steps in a generalized way.For example:
+The instructions for this lab can be found [here](https://aca-py.org/latest/demo/AriesOpenAPIDemo/) on the ACA-Py Documentation site. As you carry out the instructions, keep track of who you are on each step (Alice’s or Faber’s controller) and consider how you would code an application to automate the manual steps in a generalized way.For example:
 
 - If you really were Faber’s controller, how would you handle executing thousands of protocol instances running in parallel between you and all of Faber’s alumni?
 - How would you interface with Faber College’s backend information systems?

--- a/docs/LFS173xV2/OpenAPIControllerAIP2.md
+++ b/docs/LFS173xV2/OpenAPIControllerAIP2.md
@@ -12,7 +12,7 @@ This lab can be run locally with Docker or on Play with Docker in your browser. 
   
 ## Instructions
 
-The instructions for this lab can be found [here](https://github.com/hyperledger/aries-cloudagent-python/blob/main/demo/AliceWantsAJsonCredential.md) in the ACA-Py repository. The lab covers
+The instructions for this lab can be found [here](https://aca-py.org/latest/demo/AliceWantsAJsonCredential/) on the ACA-Py Documentation site. The lab covers
 the AIP 2.0 protocols for connecting, and uses the JSON-LD verifiable credential formats (BBS+ and LD Signatures). To exchange the JSON-LD format verifiable credentials version 2.0 if the
 Issue Credential and Present Proof protocols are used. Note that while not demonstrated in the lab, Indy AnonCred format credentials can also be exchanged using the version 2.0 credential
 exchange protocols.

--- a/docs/LFS173xV2/UsingAriesEndorserService.md
+++ b/docs/LFS173xV2/UsingAriesEndorserService.md
@@ -22,8 +22,8 @@ cd aries-cloudagent-python/demo
 
 ```
 
-The instructions for the demo can be found on the ACA-Py [Endorser Demo](https://github.com/hyperledger/aries-cloudagent-python/blob/main/demo/Endorser.md) page. The instructions are a bit sparse compared
-to the main [Alice-Faber demo instructions](https://github.com/hyperledger/aries-cloudagent-python/tree/main/demo#the-alicefaber-python-demo), but hopefully they are enough to get you through it.
+The instructions for the demo can be found on the ACA-Py [Endorser Demo](https://aca-py.org/latest/demo/Endorser/) page. The instructions are a bit sparse compared
+to the main [Alice-Faber demo instructions](https://aca-py.org/latest/demo/), but hopefully they are enough to get you through it.
 
 The main differences from a regular Alice-Faber demo run are:
 

--- a/docs/LFS173xV2/agentsConnecting.md
+++ b/docs/LFS173xV2/agentsConnecting.md
@@ -26,7 +26,7 @@ This lab from the ACA-Py repository includes details about running the example l
 
 ## Instructions
 
-This tutorial in the ACA-Py repository spins up agents for Alice and Faber and has them connect and exchange messages. Follow the [instructions here](https://github.com/hyperledger/aries-cloudagent-python/tree/main/demo#the-alicefaber-python-demo), stopping at the end of the “Exchanging Messages” section. We’ll do the rest of the tutorial later (which admittedly, isn’t much!).
+This tutorial in the ACA-Py repository spins up agents for Alice and Faber and has them connect and exchange messages. Follow the [instructions here](https://aca-py.org/latest/demo/), stopping at the end of the “Exchanging Messages” section. We’ll do the rest of the tutorial later (which admittedly, isn’t much!).
 
 One important thing to understand about this particular demo is the agent and controller integration. As we stressed in the course, ACA-Py runs two processes: one for the agent and one for the controller. However, in this demo it appears that the two are run with one command—and that can be a little confusing. In fact, they don’t run in the same **process**. The demo uses a Python feature such that the controller starts the ACA-Py instance as a sub-process. Use the links below to see the relevant code for that:
 

--- a/docs/LFS173xV2/agentsConnectingAIP2.md
+++ b/docs/LFS173xV2/agentsConnectingAIP2.md
@@ -53,7 +53,7 @@ controller) is unaffected.
 
 So, remembering the extra option and what to look at to see the difference,
 complete the lab by following the [instructions
-here](https://github.com/hyperledger/aries-cloudagent-python/tree/main/demo#the-alicefaber-python-demo),
+here](https://aca-py.org/latest/demo/),
 stop once the connection is established. The astute participants will notice
 that we don't add the extra option to the Alice agent. That's because Faber is
 initiating the invitation, and has to be told what version of invitation to


### PR DESCRIPTION
I was looking through some old notes for something about a 2.0 protocol and found a link to a lab page and noticed that a previously working link on there was broken. Looks like thinks were moved around a little to accommodate the ACA-Py Documentation site.
I did a quick search and adjusted ones I could find that were pointing to Not Found pages.

I assume they should go to the Docs website rather than the equivalent `.md` files in the repo for these lab materials? (I pointed them there rather than the repo).

These lab pages look to be linked from the lab sections in the edX course in it's currently live content.